### PR TITLE
Remove extra KnuVerse agent call

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,7 +99,6 @@ def auth2():
 <script src="https://cloud.knuverse.com/verifyme/js/knuverse_agent.js">
 </script>
 <script>
-KnuVerse.configure();
 var params = {token: '%s'};
 var callBackFunction = function(data) {
     console.log(data.token);


### PR DESCRIPTION
The KnuVerse.configure function is only necessary if the API and Auth window is not hosted on the cloud.